### PR TITLE
Fix assertion methods in ModrinthTest

### DIFF
--- a/src/main/kotlin/xyz/deathsgun/modmanager/api/mod/Mod.kt
+++ b/src/main/kotlin/xyz/deathsgun/modmanager/api/mod/Mod.kt
@@ -22,7 +22,7 @@ data class Mod(
     val author: String,
     val name: String,
     val shortDescription: String,
-    val iconUrl: String,
+    val iconUrl: String?,
     val description: String?,
     val license: String?,
     val categories: List<Category>,

--- a/src/main/kotlin/xyz/deathsgun/modmanager/providers/modrinth/models/ModResult.kt
+++ b/src/main/kotlin/xyz/deathsgun/modmanager/providers/modrinth/models/ModResult.kt
@@ -28,6 +28,6 @@ data class ModResult(
     val title: String,
     val description: String,
     @SerialName("icon_url")
-    val iconUrl: String,
+    val iconUrl: String?,
     val categories: ArrayList<String>
 )

--- a/src/test/kotlin/xyz/deathsgun/modmanager/providers/modrinth/ModrinthTest.kt
+++ b/src/test/kotlin/xyz/deathsgun/modmanager/providers/modrinth/ModrinthTest.kt
@@ -30,6 +30,7 @@ import xyz.deathsgun.modmanager.api.provider.Sorting
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -101,7 +102,7 @@ internal class ModrinthTest {
             assertTrue(it.slug.isNotEmpty())
             assertTrue(it.name.isNotEmpty())
             assertTrue(it.author.isNotEmpty())
-            assertTrue(it.iconUrl.isNotEmpty())
+            assertNotNull(it.iconUrl)
             assertTrue(it.shortDescription.isNotEmpty())
             assertTrue(it.categories.isNotEmpty())
 
@@ -132,7 +133,7 @@ internal class ModrinthTest {
         assertTrue(mod.slug.isNotEmpty())
         assertTrue(mod.name.isNotEmpty())
         assertTrue(mod.author.isNotEmpty())
-        assertTrue(mod.iconUrl.isNotEmpty())
+        assertNotNull(mod.iconUrl)
         assertTrue(mod.shortDescription.isNotEmpty())
         assertTrue(mod.categories.isNotEmpty())
         assertNotEquals(mod.description, null)

--- a/src/test/kotlin/xyz/deathsgun/modmanager/providers/modrinth/ModrinthTest.kt
+++ b/src/test/kotlin/xyz/deathsgun/modmanager/providers/modrinth/ModrinthTest.kt
@@ -30,6 +30,8 @@ import xyz.deathsgun.modmanager.api.provider.Sorting
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 internal class ModrinthTest {
 
@@ -45,9 +47,9 @@ internal class ModrinthTest {
             fail(result.text.key)
         }
         val categories = (result as CategoriesResult.Success).categories
-        assert(categories.isNotEmpty())
+        assertTrue(categories.isNotEmpty())
         categories.forEach {
-            assert(it.id.isNotEmpty())
+            assertTrue(it.id.isNotEmpty())
             assertEquals(String.format("modmanager.category.%s", it.id), it.text.key)
         }
     }
@@ -92,20 +94,20 @@ internal class ModrinthTest {
     }
 
     private fun checkMods(mods: List<Mod>) {
-        assert(mods.isNotEmpty())
+        assertTrue(mods.isNotEmpty())
         assertEquals(mods.size, 10)
         mods.forEach {
-            assert(it.id.isNotEmpty())
-            assert(it.slug.isNotEmpty())
-            assert(it.name.isNotEmpty())
-            assert(it.author.isNotEmpty())
-            assert(it.iconUrl.isNotEmpty())
-            assert(it.shortDescription.isNotEmpty())
-            assert(it.categories.isNotEmpty())
+            assertTrue(it.id.isNotEmpty())
+            assertTrue(it.slug.isNotEmpty())
+            assertTrue(it.name.isNotEmpty())
+            assertTrue(it.author.isNotEmpty())
+            assertTrue(it.iconUrl.isNotEmpty())
+            assertTrue(it.shortDescription.isNotEmpty())
+            assertTrue(it.categories.isNotEmpty())
 
             // Only filled when getMod(id) is called
-            assertEquals(null, it.description, "description should be null as it's only loaded by getMod")
-            assertEquals(null, it.license, "description should be null as it's only loaded by getMod")
+            assertNull(it.description, "description should be null as it's only loaded by getMod")
+            assertNull(it.license, "description should be null as it's only loaded by getMod")
         }
     }
 
@@ -126,17 +128,17 @@ internal class ModrinthTest {
             fail(result.text.key)
         }
         val mod = (result as ModResult.Success).mod
-        assert(mod.id.isNotEmpty())
-        assert(mod.slug.isNotEmpty())
-        assert(mod.name.isNotEmpty())
-        assert(mod.author.isNotEmpty())
-        assert(mod.iconUrl.isNotEmpty())
-        assert(mod.shortDescription.isNotEmpty())
-        assert(mod.categories.isNotEmpty())
+        assertTrue(mod.id.isNotEmpty())
+        assertTrue(mod.slug.isNotEmpty())
+        assertTrue(mod.name.isNotEmpty())
+        assertTrue(mod.author.isNotEmpty())
+        assertTrue(mod.iconUrl.isNotEmpty())
+        assertTrue(mod.shortDescription.isNotEmpty())
+        assertTrue(mod.categories.isNotEmpty())
         assertNotEquals(mod.description, null)
-        assert(mod.description!!.isNotEmpty())
+        assertTrue(mod.description!!.isNotEmpty())
         assertNotEquals(mod.license, null)
-        assert(mod.license!!.isNotEmpty())
+        assertTrue(mod.license!!.isNotEmpty())
     }
 
     @Test
@@ -149,19 +151,19 @@ internal class ModrinthTest {
             fail(result.text.key)
         }
         val versions = (result as VersionResult.Success).versions
-        assert(versions.isNotEmpty())
+        assertTrue(versions.isNotEmpty())
         versions.forEach {
-            assert(it.gameVersions.isNotEmpty())
+            assertTrue(it.gameVersions.isNotEmpty())
             assertContains(it.gameVersions, "1.17.1")
-            assert(it.version.isNotEmpty())
-            assert(it.changelog.isNotEmpty())
+            assertTrue(it.version.isNotEmpty())
+            assertTrue(it.changelog.isNotEmpty())
             assertEquals(VersionType.ALPHA, it.type)
-            assert(it.assets.isNotEmpty())
+            assertTrue(it.assets.isNotEmpty())
             it.assets.forEach { asset ->
-                assert(asset.filename.isNotEmpty())
-                assert(asset.filename.endsWith(".jar"))
-                assert(asset.url.isNotEmpty())
-                assert(asset.hashes.isNotEmpty())
+                assertTrue(asset.filename.isNotEmpty())
+                assertTrue(asset.filename.endsWith(".jar"))
+                assertTrue(asset.url.isNotEmpty())
+                assertTrue(asset.hashes.isNotEmpty())
                 assertContains(asset.hashes, "sha512")
             }
         }


### PR DESCRIPTION
Using the JVM `assert` method results in poor test output on failure. This PR switches all checks to `assertTrue` and `assertNull` from `kotlin.test` which integrates better with the test framework. There is a failing test in `ModrinthTest` that was broken on the `kotlin` branch itself and I have not made an attempt to fix it since I'm unfamiliar with the codebase at the moment.
