### PR TITLE
Overwrite files to delete and delete them fully on restart

### DIFF
--- a/src/main/kotlin/xyz/deathsgun/modmanager/ModManager.kt
+++ b/src/main/kotlin/xyz/deathsgun/modmanager/ModManager.kt
@@ -68,6 +68,7 @@ class ModManager : ClientModInitializer {
         provider[modrinth.getName().lowercase()] = modrinth
         updateProvider[modrinth.getName().lowercase()] = modrinth
         GlobalScope.launch {
+            update.fullyDeleteMods()
             update.checkUpdates()
             icons.cleanupCache()
         }


### PR DESCRIPTION
Windows doesn't allow you to delete files while there are open in a program. So I can't delete the jars on Windows directly. So write "MODMANAGER" into the jar to make it invalid. After that when minecraft restarts it will be deleted by ModManager.

Closes #51 

Signed-off-by: DeathsGun <deathsgun@protonmail.com>